### PR TITLE
chore: zeebe-http-cloudevents-worker to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.89
+- name: zeebe-http-cloudevents-worker
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.3
 - name: zeebe-operator
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.64


### PR DESCRIPTION
chore: Promote zeebe-http-cloudevents-worker to version 0.0.3