### PR TITLE
chore: vertx-cloud-events to 1.0.13

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.89
 - name: vertx-cloud-events
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.12
+  version: 1.0.13
 - name: zeebe-http-cloudevents-worker
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.4


### PR DESCRIPTION
chore: Promote vertx-cloud-events to version 1.0.13