### PR TITLE
chore: zeebe-http-cloudevents-worker to 0.0.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 1.0.18
 - name: zeebe-http-cloudevents-worker
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.4
+  version: 0.0.7
 - name: zeebe-operator
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.64


### PR DESCRIPTION
chore: Promote zeebe-http-cloudevents-worker to version 0.0.7