### PR TITLE
chore: spring-boot-starter-cloudevents to 0.0.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.89
 - name: spring-boot-starter-cloudevents
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.7
 - name: zeebe-3675-reproducer
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.4


### PR DESCRIPTION
chore: Promote spring-boot-starter-cloudevents to version 0.0.7