### PR TITLE
chore: zeebe-http-cloudevents-worker to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,6 +13,9 @@ dependencies:
 - name: zeebe-3675-reproducer
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.4
+- name: zeebe-http-cloudevents-worker
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.9
 - name: zeebe-operator
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.69


### PR DESCRIPTION
chore: Promote zeebe-http-cloudevents-worker to version 0.0.9