### PR TITLE
chore: zeebe-http-cloudevents-worker to 0.0.10

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
   version: 0.0.4
 - name: zeebe-http-cloudevents-worker
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.9
+  version: 0.0.10
 - name: zeebe-operator
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.69


### PR DESCRIPTION
chore: Promote zeebe-http-cloudevents-worker to version 0.0.10