### PR TITLE
chore: spring-boot-starter-cloudevents to 0.0.12

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.89
 - name: spring-boot-starter-cloudevents
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.11
+  version: 0.0.12
 - name: vertx-cloud-events
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.19


### PR DESCRIPTION
chore: Promote spring-boot-starter-cloudevents to version 0.0.12