### PR TITLE
chore: spring-boot-starter-cloudevents2 to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,6 +10,9 @@ dependencies:
 - name: spring-boot-starter-cloudevents
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.12
+- name: spring-boot-starter-cloudevents2
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.2
 - name: vertx-cloud-events
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.19


### PR DESCRIPTION
chore: Promote spring-boot-starter-cloudevents2 to version 0.0.2