### PR TITLE
chore: spring-boot-starter-cloudevents2 to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.15
 - name: spring-boot-starter-cloudevents2
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.3
+  version: 0.0.4
 - name: vertx-cloud-events
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.19


### PR DESCRIPTION
chore: Promote spring-boot-starter-cloudevents2 to version 0.0.4