### PR TITLE
chore: zeebe-cloud-events-router to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -19,6 +19,9 @@ dependencies:
 - name: zeebe-3675-reproducer
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.4
+- name: zeebe-cloud-events-router
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1
 - name: zeebe-http-cloudevents-worker
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.10


### PR DESCRIPTION
chore: Promote zeebe-cloud-events-router to version 0.0.1