### PR TITLE
chore: zeebe-cloud-events-router to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 0.0.4
 - name: zeebe-cloud-events-router
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2
 - name: zeebe-http-cloudevents-worker
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.10


### PR DESCRIPTION
chore: Promote zeebe-cloud-events-router to version 0.0.2