### PR TITLE
chore: zeebe-k8s-tests to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -33,7 +33,7 @@ dependencies:
   version: 0.0.10
 - name: zeebe-k8s-tests
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 0.0.3
 - name: zeebe-operator
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.73


### PR DESCRIPTION
chore: Promote zeebe-k8s-tests to version 0.0.3